### PR TITLE
Added sidebar route to get the names of all external tools

### DIFF
--- a/server/src/controllers/plugin-info.js
+++ b/server/src/controllers/plugin-info.js
@@ -1,12 +1,35 @@
 const response = require("../utils/response");
 
+const appInfo = [
+  {
+    name: "GITHUB",
+    logo: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+  },
+  {
+    name: "FIGMA",
+    logo: "https://cdn.sanity.io/images/599r6htc/production/46a76c802176eb17b04e12108de7e7e0f3736dc6-1024x1024.png?w=670&h=670&q=75&fit=max&auto=format",
+  },
+  {
+    name: "GOOGLE DRIVE",
+    logo: "https://upload.wikimedia.org/wikipedia/commons/d/da/Google_Drive_logo.png",
+  },
+  {
+    name: "GIPHY",
+    logo: "https://images-eu.ssl-images-amazon.com/images/I/113Ja712zxL.png",
+  },
+  {
+    name: "GMAIL",
+    logo: "https://cdn.icon-icons.com/icons2/2631/PNG/512/gmail_new_logo_icon_159149.png",
+  },
+];
+
 class PluginInfoController {
   async getInfo(req, res) {
-    
     res.send(response("Plugin Info returned successfully"));
   }
-
-   
+  async getAllApps(req, res) {
+    res.json(appInfo);
+  }
 }
 
 module.exports = new PluginInfoController();

--- a/server/src/controllers/plugin-info.js
+++ b/server/src/controllers/plugin-info.js
@@ -1,27 +1,6 @@
 const response = require("../utils/response");
 
-const appInfo = [
-  {
-    name: "GITHUB",
-    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613460/GitHub-Mark_v0odrb.png",
-  },
-  {
-    name: "FIGMA",
-    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613524/46a76c802176eb17b04e12108de7e7e0f3736dc6-1024x1024_bq4w0h.png",
-  },
-  {
-    name: "GOOGLE DRIVE",
-    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613549/Google_Drive_logo_i0llf0.png",
-  },
-  {
-    name: "GIPHY",
-    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613567/113Ja712zxL_xtxsun.png",
-  },
-  {
-    name: "GMAIL",
-    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613587/gmail_new_logo_icon_159149_jchsqd.png",
-  },
-];
+const appInfo = ["GITHUB", "FIGMA", "GOOGLE DRIVE", "GIPHY", "GMAIL"];
 
 class PluginInfoController {
   async getInfo(req, res) {

--- a/server/src/controllers/plugin-info.js
+++ b/server/src/controllers/plugin-info.js
@@ -1,13 +1,13 @@
 const response = require("../utils/response");
 
-const appInfo = ["GITHUB", "FIGMA", "GOOGLE DRIVE", "GIPHY", "GMAIL"];
+const apps = ["GITHUB", "FIGMA", "GOOGLE DRIVE", "GIPHY", "GMAIL"];
 
 class PluginInfoController {
   async getInfo(req, res) {
     res.send(response("Plugin Info returned successfully"));
   }
   async getAllApps(req, res) {
-    res.json(appInfo);
+    res.json(apps);
   }
 }
 

--- a/server/src/controllers/plugin-info.js
+++ b/server/src/controllers/plugin-info.js
@@ -3,23 +3,23 @@ const response = require("../utils/response");
 const appInfo = [
   {
     name: "GITHUB",
-    logo: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613460/GitHub-Mark_v0odrb.png",
   },
   {
     name: "FIGMA",
-    logo: "https://cdn.sanity.io/images/599r6htc/production/46a76c802176eb17b04e12108de7e7e0f3736dc6-1024x1024.png?w=670&h=670&q=75&fit=max&auto=format",
+    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613524/46a76c802176eb17b04e12108de7e7e0f3736dc6-1024x1024_bq4w0h.png",
   },
   {
     name: "GOOGLE DRIVE",
-    logo: "https://upload.wikimedia.org/wikipedia/commons/d/da/Google_Drive_logo.png",
+    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613549/Google_Drive_logo_i0llf0.png",
   },
   {
     name: "GIPHY",
-    logo: "https://images-eu.ssl-images-amazon.com/images/I/113Ja712zxL.png",
+    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613567/113Ja712zxL_xtxsun.png",
   },
   {
     name: "GMAIL",
-    logo: "https://cdn.icon-icons.com/icons2/2631/PNG/512/gmail_new_logo_icon_159149.png",
+    logo: "https://res.cloudinary.com/pablowolf/image/upload/v1630613587/gmail_new_logo_icon_159149_jchsqd.png",
   },
 ];
 

--- a/server/src/routes/plugin-info.js
+++ b/server/src/routes/plugin-info.js
@@ -2,10 +2,9 @@ const router = require("express").Router();
 
 const pluginInfoController = require("../controllers/plugin-info");
 
-
 module.exports = function () {
   router.get("/info", pluginInfoController.getInfo);
-
+  router.get("/apps", pluginInfoController.getAllApps);
 
   return router;
 };

--- a/server/src/routes/plugin-info.js
+++ b/server/src/routes/plugin-info.js
@@ -4,7 +4,7 @@ const pluginInfoController = require("../controllers/plugin-info");
 
 module.exports = function () {
   router.get("/info", pluginInfoController.getInfo);
-  router.get("/apps", pluginInfoController.getAllApps);
+  router.get("/sidebar", pluginInfoController.getAllApps);
 
   return router;
 };


### PR DESCRIPTION
The route /api/sidebar returns an array of all the externals tools in zuri chat
 Fixes [Issue #307](https://github.com/zurichat/zc_plugin_tools/issues/307)



Sub team lead @alvacoder test my code 