### PR TITLE
Add github give permission page to zuri chat

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "postcss": "^7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.2.0",
     "react-router-dom": "^5.2.1",
     "react-scripts": "4.0.3",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",

--- a/client/src/components/Apps/Github/Github.js
+++ b/client/src/components/Apps/Github/Github.js
@@ -1,7 +1,15 @@
 import React from "react";
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import Githubgivepermission from './containers/Githubgivepermission';
 
 const Github = () => {
-  return <div>This is the github page</div>;
+  return <>
+    <Router>
+    <Switch>
+      <Route exact path='/github/githubgivepermission' component={Githubgivepermission} />
+    </Switch>
+  </Router>
+  </>;
 };
 
 export default Github;

--- a/client/src/components/Apps/Github/containers/Githubgivepermission.js
+++ b/client/src/components/Apps/Github/containers/Githubgivepermission.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import '../style/githubgivepermission.css';
+import { BiMessageAltDetail } from 'react-icons/bi';
+import { CgMicrosoft } from 'react-icons/cg';
+import { BsFillCaretRightFill } from 'react-icons/bs';
+import { CgArrowsExchangeAlt } from 'react-icons/cg';
+
+const Githubgivepermission = () => {
+    return (
+        <section className="ggpSection">
+            <div className="ggpdiv">
+                <p className="ggpP">
+                    <img
+                        src='https://image.flaticon.com/icons/png/512/25/25231.png'
+                        alt='github logo'
+                        className="ggpimg"
+                    />
+                    <CgArrowsExchangeAlt />
+                    <svg className="ggpimg" width="30" height="30" viewBox="0 0 30 31" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3.91602" width="11.7504" height="11.7504" rx="1.0991" fill="#00B87C"/>
+<rect y="13.4291" width="11.7504" height="11.7504" rx="1.0991" fill="#FEA162"/>
+<rect x="17.3457" y="5.59546" width="11.7504" height="11.7504" rx="1.0991" fill="#1A61DB"/>
+<rect x="13.4297" y="19.0244" width="11.7504" height="11.7504" rx="1.0991" fill="#DC1AA3"/>
+</svg>
+                </p>
+                <div className="ggpdiv2">
+                    <p className="ggpBold ggpMargintop">Github is requesting permission to access the Zuri workspace</p>
+                </div>
+                <div className="ggpLeft">
+                    <div>
+                        <p className="ggpMargintop ggpBold ggpSmallfont">What will Github be able to view?</p>
+                    </div>
+                    <div>
+                    
+                        <p className="ggpMargintop ggpSmallfont ggpFlex"><BiMessageAltDetail /><span className="ggpspan">Content and info about channel and conversations</span><BsFillCaretRightFill /></p>
+                        <p className="ggpSmallfont ggpFlex"><span className="ggpspan2">View basic information about public channels in your workspace</span></p>
+                        <p className="ggpSmallfont ggpFlex"><span className="ggpspan2">View basic information about private channels that Github has been added to</span></p>
+                        <p className="ggpSmallfont ggpFlex"><span className="ggpspan2">View basic information about direct messages that Github has been added to</span></p>
+                    </div>
+                    <div>
+                    
+                        <p className="ggpMargintop ggpSmallfont ggpFlex"><CgMicrosoft /><span className="ggpspan">Content and info about your workspace</span><BsFillCaretRightFill /></p>
+                    </div>
+                    <div>
+                        <p className="ggpMargintop ggpBold ggpSmallfont">What will Github be able to do?</p>
+                    </div>
+                    <div>
+                    
+                        <p className="ggpMargintop ggpSmallfont ggpFlex"><BiMessageAltDetail /><span className="ggpspan">Perform actions in channels and conversations</span><BsFillCaretRightFill /></p>
+                    </div>
+                    <div>
+                    
+                        <p className="ggpMargintop ggpSmallfont ggpFlex"><CgMicrosoft /><span className="ggpspan">Perform actions in your workspace</span><BsFillCaretRightFill /></p>
+                    </div>
+                </div>
+                <div className="ggpdiv3">
+              <button
+                className="ggpbtn"
+              >
+                Cancel
+              </button>
+              <button
+                disabled='disabled'
+                className="ggpbtn2"
+              >
+                Allow
+              </button>
+            </div>
+            </div>
+        </section>
+    );
+};
+
+export default Githubgivepermission;

--- a/client/src/components/Apps/Github/style/githubgivepermission.css
+++ b/client/src/components/Apps/Github/style/githubgivepermission.css
@@ -1,0 +1,99 @@
+.ggpSection {
+    padding: 0 300px;
+}
+
+.ggpdiv {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    flex-direction: column;
+    width: 100%;
+    height: 100vh;
+}
+
+.ggpimg {
+    width: 30px;
+    height: 30px;
+    display: inline;
+    margin: 0 30px;
+}
+
+.ggpdiv .ggpP {
+    align-self: center;
+}
+
+.ggpdiv .ggpdiv2 {
+    align-self: center;
+    margin-bottom: 20px;
+}
+
+.ggpdiv .ggpdiv3 {
+    align-self: center;
+    margin-bottom: 20px;
+}
+
+.ggpP {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.ggpbtn2 {
+    color: white;
+    background-color: #00B87C;
+    margin: 20px;
+    padding: 4px 13px;
+    border-style: solid;
+    border-color: #00B87C;
+    border-width: 1px;
+}
+
+.ggpbtn {
+    color: #00B87C;
+    background:none;
+    margin: 20px;
+    padding: 4px 13px;
+    border-style: solid;
+    border-color: #00B87C;
+    border-width: 1px;
+}
+
+.ggpFlex {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.ggpspan {
+    margin-left: 20px;
+    margin-right: 50px;
+    font-weight: 700;
+}
+
+.ggpspan2 {
+    margin-left: 35px;
+    margin-right: 50px;
+    margin-top: 10px;
+}
+
+.ggpBold {
+    font-weight: 900;
+}
+
+.ggpMargintop {
+    margin-top: 20px;
+}
+
+.ggpSmallfont {
+    font-size: 80%;
+}
+
+.ggpLeft {
+    text-align: left;
+}
+
+@media only screen and (max-width:780px){
+	.ggpSection {
+        padding: 0 70px;
+    }
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9410,6 +9410,11 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
+react-icons@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
+  integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
+
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Fixes #305 

I worked on the page that you will be redirected to when you click on add github plugin in the zuri chat company tools plugin. That page will request permission from zuri to access github.


**Description of Task to be completed?**

This task adds a page that is displayed when a user clicks on add github in the github home page. It is the ui that is displayed in order to authorise zuri's access to github.



**How should this be manually tested?**

Live link: https://githubgivepermission.netlify.app/github/githubgivepermission



**Any background context you want to provide?**

Any pertinent information that should be considered



**What is the link to the issue on Github?**

[Issue #305](https://github.com/zurichat/zc_plugin_tools/issues/305)



**Questions:**

If something is unclear or you want some questions to be addressed by your peers, mention them here