### PR TITLE
Add github request permission page to zuri chat

### DIFF
--- a/client/src/components/Apps/Github/Github.js
+++ b/client/src/components/Apps/Github/Github.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import GithubHome from "./containers/GithubHome";
+import Githubgivepermission from "./containers/Githubgivepermission";
 
 const Github = () => {
   return (
@@ -8,6 +9,7 @@ const Github = () => {
       <Router>
         <Switch>
           <Route exact path='/github' component={GithubHome} />
+          <Route exact path='/github/githubgivepermission' component={Githubgivepermission} />
         </Switch>
       </Router>
     </>

--- a/client/src/components/Apps/Github/containers/GithubHome.js
+++ b/client/src/components/Apps/Github/containers/GithubHome.js
@@ -30,13 +30,13 @@ const GithubHome = () => {
             </div>
             <div className={`github_btn_container flex flex-col gap-2`}>
               <button
-                disabled='disabled'
+                onClick={()=> window.open("/github/Githubgivepermission", "_blank")}
                 className={`github_btn_container-btn bg-githubGreen text-white`}
               >
                 Add to Zuri Chat
               </button>
               <button
-                disabled='disabled'
+                
                 className={`github_btn_container-btn bg-transparent text-githubGreen`}
               >
                 Learn More

--- a/client/src/components/Apps/Github/containers/Githubgivepermission.js
+++ b/client/src/components/Apps/Github/containers/Githubgivepermission.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import '../style/githubgivepermission.css';
+import { BiMessageAltDetail } from 'react-icons/bi';
+import { CgMicrosoft } from 'react-icons/cg';
+import { BsFillCaretRightFill } from 'react-icons/bs';
+import { CgArrowsExchangeAlt } from 'react-icons/cg';
+
+const Githubgivepermission = () => {
+    return (
+        <section className="ggpSection">
+            <div className="ggpdiv">
+                <p className="ggpP">
+                    <img
+                        src='https://image.flaticon.com/icons/png/512/25/25231.png'
+                        alt='github logo'
+                        className="ggpimg"
+                    />
+                    <CgArrowsExchangeAlt />
+                    <svg className="ggpimg" width="30" height="30" viewBox="0 0 30 31" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3.91602" width="11.7504" height="11.7504" rx="1.0991" fill="#00B87C"/>
+<rect y="13.4291" width="11.7504" height="11.7504" rx="1.0991" fill="#FEA162"/>
+<rect x="17.3457" y="5.59546" width="11.7504" height="11.7504" rx="1.0991" fill="#1A61DB"/>
+<rect x="13.4297" y="19.0244" width="11.7504" height="11.7504" rx="1.0991" fill="#DC1AA3"/>
+</svg>
+                </p>
+                <div className="ggpdiv2">
+                    <p className="ggpBold ggpMargintop">Github is requesting permission to access the Zuri workspace</p>
+                </div>
+                <div className="ggpLeft">
+                    <div>
+                        <p className="ggpMargintop ggpBold ggpSmallfont">What will Github be able to view?</p>
+                    </div>
+                    <div>
+                    
+                        <p className="ggpMargintop ggpSmallfont ggpFlex"><BiMessageAltDetail /><span className="ggpspan">Content and info about channel and conversations</span><BsFillCaretRightFill /></p>
+                        <p className="ggpSmallfont ggpFlex"><span className="ggpspan2">View basic information about public channels in your workspace</span></p>
+                        <p className="ggpSmallfont ggpFlex"><span className="ggpspan2">View basic information about private channels that Github has been added to</span></p>
+                        <p className="ggpSmallfont ggpFlex"><span className="ggpspan2">View basic information about direct messages that Github has been added to</span></p>
+                    </div>
+                    <div>
+                    
+                        <p className="ggpMargintop ggpSmallfont ggpFlex"><CgMicrosoft /><span className="ggpspan">Content and info about your workspace</span><BsFillCaretRightFill /></p>
+                    </div>
+                    <div>
+                        <p className="ggpMargintop ggpBold ggpSmallfont">What will Github be able to do?</p>
+                    </div>
+                    <div>
+                    
+                        <p className="ggpMargintop ggpSmallfont ggpFlex"><BiMessageAltDetail /><span className="ggpspan">Perform actions in channels and conversations</span><BsFillCaretRightFill /></p>
+                    </div>
+                    <div>
+                    
+                        <p className="ggpMargintop ggpSmallfont ggpFlex"><CgMicrosoft /><span className="ggpspan">Perform actions in your workspace</span><BsFillCaretRightFill /></p>
+                    </div>
+                </div>
+                <div className="ggpdiv3">
+              <button
+                className="ggpbtn"
+              >
+                Cancel
+              </button>
+              <button
+                disabled='disabled'
+                className="ggpbtn2"
+              >
+                Allow
+              </button>
+            </div>
+            </div>
+        </section>
+    );
+};
+
+export default Githubgivepermission;

--- a/client/src/components/Apps/Github/style/githubgivepermission.css
+++ b/client/src/components/Apps/Github/style/githubgivepermission.css
@@ -1,0 +1,99 @@
+.ggpSection {
+    padding: 0 300px;
+}
+
+.ggpdiv {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    flex-direction: column;
+    width: 100%;
+    height: 100vh;
+}
+
+.ggpimg {
+    width: 30px;
+    height: 30px;
+    display: inline;
+    margin: 0 30px;
+}
+
+.ggpdiv .ggpP {
+    align-self: center;
+}
+
+.ggpdiv .ggpdiv2 {
+    align-self: center;
+    margin-bottom: 20px;
+}
+
+.ggpdiv .ggpdiv3 {
+    align-self: center;
+    margin-bottom: 20px;
+}
+
+.ggpP {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.ggpbtn2 {
+    color: white;
+    background-color: #00B87C;
+    margin: 20px;
+    padding: 4px 13px;
+    border-style: solid;
+    border-color: #00B87C;
+    border-width: 1px;
+}
+
+.ggpbtn {
+    color: #00B87C;
+    background:none;
+    margin: 20px;
+    padding: 4px 13px;
+    border-style: solid;
+    border-color: #00B87C;
+    border-width: 1px;
+}
+
+.ggpFlex {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.ggpspan {
+    margin-left: 20px;
+    margin-right: 50px;
+    font-weight: 700;
+}
+
+.ggpspan2 {
+    margin-left: 35px;
+    margin-right: 50px;
+    margin-top: 10px;
+}
+
+.ggpBold {
+    font-weight: 900;
+}
+
+.ggpMargintop {
+    margin-top: 20px;
+}
+
+.ggpSmallfont {
+    font-size: 80%;
+}
+
+.ggpLeft {
+    text-align: left;
+}
+
+@media only screen and (max-width:780px){
+	.ggpSection {
+        padding: 0 70px;
+    }
+}


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run eslint` to find errors in code syntax/format
- Run `npm run eslint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands
- Ensure you fix all merge conflicts before sending PR

**What does this PR do?**

Fixes #305 

The page i created is the page that appears when github wants to request permission from zuri chat



**Description of Task to be completed?**

I created a page which will appear when user clicks on add github in the zuri tools plugin. This page will be able to make github request permission from zuri chat to allow some certain things.



**How should this be manually tested?**

https://adoring-lamport-97b0bc.netlify.app/github/Githubgivepermission



**Any background context you want to provide?**

Any pertinent information that should be considered



**What is the link to the issue on Github?**

[Issue #305](https://github.com/zurichat/zc_plugin_tools/issues/305)



**Questions:**

If something is unclear or you want some questions to be addressed by your peers, mention them here