### PR TITLE
Add the back to tools button for all tool pages on the plugin

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,25 +10,45 @@ import Giphy from "./components/Apps/Giphy/Giphy";
 import GoogleDrive from "./components/Apps/GoogleDrive/GoogleDrive";
 import FigmaSubRoutes from "./components/Apps/Figma/SubRoute";
 // import Layout from "./components/layout/layout";
-// import HomeLayoutRoutes from "./components/allroutes/homeRoutesLayout";
-// import AppLayoutRoutes from "./components/allroutes/appRoutesLayout";
+import HomeLayoutRoutes from "./components/allroutes/homeRoutesLayout";
+import AppLayoutRoutes from "./components/allroutes/appRoutesLayout";
+import ToolsDirectoryLayout from "./components/allroutes/toolsDirectoryLayout";
 
 function App() {
   return (
     <div className="flex flex-grow min-h-screen">
       <div className="flex-grow bg-gray-200">
-        <BrowserRouter>
+        {/* <BrowserRouter>
           <Switch>
-            {/* <Layout> */}
             <Route exact path="/" component={ToolsView} />
             <Route exact path="/tools" component={ToolsDirectory} />
-            {/* <ToolsHeader /> */}
             <Route path="/gmail" component={Gmail} />
             <Route path="/figma/:subroute" component={FigmaSubRoutes} />
             <Route path="/figma" component={Figma} />
             <Route path="/github" component={Github} />
             <Route path="/giphy" component={Giphy} />
             <Route path="/googledrive" component={GoogleDrive} />
+          </Switch>
+        </BrowserRouter> */}
+        <BrowserRouter>
+          <Switch>
+            {/* <Layout> */}
+            <HomeLayoutRoutes exact path="/" component={ToolsView} />
+            <ToolsDirectoryLayout
+              exact
+              path="/tools"
+              component={ToolsDirectory}
+            />
+            {/* <ToolsHeader /> */}
+            <AppLayoutRoutes path="/gmail" component={Gmail} />
+            <AppLayoutRoutes
+              path="/figma/:subroute"
+              component={FigmaSubRoutes}
+            />
+            <AppLayoutRoutes path="/figma" component={Figma} />
+            <AppLayoutRoutes path="/github" component={Github} />
+            <AppLayoutRoutes path="/giphy" component={Giphy} />
+            <AppLayoutRoutes path="/googledrive" component={GoogleDrive} />
             {/* </ToolsHeader> */}
             {/* </Layout> */}
           </Switch>

--- a/client/src/components/Apps/Figma/Figma.js
+++ b/client/src/components/Apps/Figma/Figma.js
@@ -5,7 +5,7 @@ import FigmaAbout from "./about-secttion/FigmaAbout";
 import FigmaMessages from "./messages-section/FigmaMessages";
 import logo from "./images/fignaLogo.png";
 import "./css/Figma.css";
-import ToolsHeader from "../../toolsheader/toolsheader";
+// import ToolsHeader from "../../toolsheader/toolsheader";
 
 const initialState = {
   page: "about",
@@ -24,7 +24,7 @@ class Figma extends Component {
 
     return (
       <>
-        <ToolsHeader />
+        {/* <ToolsHeader /> */}
         <SearchBar />
         <div className="Start-title">
           <div className="figmalogo-container">

--- a/client/src/components/Apps/Giphy/Giphy.js
+++ b/client/src/components/Apps/Giphy/Giphy.js
@@ -1,10 +1,10 @@
-import ToolsHeader from "../../toolsheader/toolsheader";
+// import ToolsHeader from "../../toolsheader/toolsheader";
 import DescriptionAction from "./descriptionActions/descriptionAction";
 
 const Giphy = () => {
   return (
     <>
-      <ToolsHeader />
+      {/* <ToolsHeader /> */}
       <div>
         <DescriptionAction />
       </div>

--- a/client/src/components/Apps/Github/Github.js
+++ b/client/src/components/Apps/Github/Github.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import ToolsHeader from "../../toolsheader/toolsheader";
+// import ToolsHeader from "../../toolsheader/toolsheader";
 import GithubHome from "./containers/GithubHome";
 
 const Github = () => {
   return (
     <>
-      <ToolsHeader />
+      {/* <ToolsHeader /> */}
       <Router>
         <Switch>
           <Route exact path="/github" component={GithubHome} />

--- a/client/src/components/Apps/Github/containers/GithubHome.js
+++ b/client/src/components/Apps/Github/containers/GithubHome.js
@@ -1,13 +1,13 @@
 import React from "react";
-import { Link } from "react-router-dom";
-import { IoChevronBackOutline } from "react-icons/io5";
+// import { Link } from "react-router-dom";
+// import { IoChevronBackOutline } from "react-icons/io5";
 import Image from "../assets/ZV_64LdGoao.jpg";
 import GithubLogo from "../assets/Rectangle 693.jpg";
 import "../style/GithubHome.css";
 const GithubHome = () => {
   return (
     <section className="github_home github_home_padding">
-      <div className="top_nav">
+      {/* <div className="top_nav">
         <h2 className={`font-bold text-lg lg:text-lg xl:text-xl 2xl:text-2xl`}>
           Tool Directory
         </h2>
@@ -18,7 +18,7 @@ const GithubHome = () => {
           <IoChevronBackOutline />
           Back home
         </Link>
-      </div>
+      </div> */}
       <div className={`github_home_main`}>
         <section className={`github_home_main-section1`}>
           <div className={`flex flex-col gap-4`}>

--- a/client/src/components/Apps/Gmail/Gmail.js
+++ b/client/src/components/Apps/Gmail/Gmail.js
@@ -1,19 +1,14 @@
 import React from "react";
 // import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 // import { faAngleDoubleLeft } from "@fortawesome/free-solid-svg-icons";
-import { useHistory } from "react-router-dom";
-import ToolsHeader from "../../toolsheader/toolsheader";
+// import { useHistory } from "react-router-dom";
+// import ToolsHeader from "../../toolsheader/toolsheader";
 
 const Gmail = () => {
-  const history = useHistory();
-
-  const handleClick = () => {
-    history.push("/");
-  };
   return (
     // Please Clean the code below and add your code to complete your task, This is an example code that can be deleted
     <>
-      <ToolsHeader />
+      {/* <ToolsHeader /> */}
       <div className="flex flex-col h-screen">
         {/* <div
         onClick={handleClick}

--- a/client/src/components/Apps/GoogleDrive/GoogleDrive.js
+++ b/client/src/components/Apps/GoogleDrive/GoogleDrive.js
@@ -5,15 +5,15 @@ import About from "./About/About";
 import { useHistory } from "react-router-dom";
 // import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 // import { faAngleDoubleLeft } from "@fortawesome/free-solid-svg-icons";
-import ToolsHeader from "../../toolsheader/toolsheader";
+// import ToolsHeader from "../../toolsheader/toolsheader";
 
 const GoogleDrive = () => {
   const [page, setPage] = useState("messages");
   const history = useHistory();
 
-  const handleClick = () => {
-    history.push("/");
-  };
+  // const handleClick = () => {
+  //   history.push("/");
+  // };
   // console.log(page);
 
   return (
@@ -27,7 +27,7 @@ const GoogleDrive = () => {
         </div>
         <div className="">back to main</div>
       </div> */}
-      <ToolsHeader />
+      {/* <ToolsHeader /> */}
       <div className={styles.container}>
         <div className={styles.layer1}></div>
 

--- a/client/src/components/HeroSection/HeroSection.js
+++ b/client/src/components/HeroSection/HeroSection.js
@@ -1,46 +1,53 @@
-import styles from "./HeroSection.module.css"
-import HeroLaptopImg from "../../assets/hero-laptop.png"
-import DoubleRightArrow from "../../assets/double-arrow-right-icon.svg"
+import styles from "./HeroSection.module.css";
+import HeroLaptopImg from "../../assets/hero-laptop.png";
+import DoubleRightArrow from "../../assets/double-arrow-right-icon.svg";
+import { Link } from "react-router-dom";
 
-import React from 'react'
+import React from "react";
 
-const HeroSection = ({showHeroSection}) => {
-    return (
-        <div className ={styles.hero_section}>
-            <div className={styles.title_box}>
-                <p className={styles.title}>tools</p>
-                <div className={styles.directory_box}>
-                    <div className={styles.icon}><img src={DoubleRightArrow} alt="double_arrow-icon" /></div>
-                    <div className={styles.directory_text}>Tool Directory</div>
-                </div>
-            </div>
-            {/* end of title box */}
-            <div className={styles.content_box}>
-                <span className={styles.cancel} onClick ={showHeroSection}>&times;</span>
-                <div className={styles.content_wrap}>
-                    <div className={styles.title}>Powerful tools integrated just for Zuri chat</div>
-                    <p className={styles.text}>Tools belong to you and your team, and they
-                     provide you extra features to make you more productive. 
-                    Install once and everyone can make use of them.</p>
-                    <button className={styles.btn}>Browse available tools</button>
-                </div>
-                {/* end of content-wrap */}
-                <div className={styles.image_box}>
-                    <figure className={styles.img_wrap}>
-                    <img src={HeroLaptopImg} alt="" className={styles.img} />
-                    </figure>
-                </div>
-            </div>
-        {/* end of content box */}
+const HeroSection = ({ showHeroSection }) => {
+  return (
+    <div className={styles.hero_section}>
+      <div className={styles.title_box}>
+        <p className={styles.title}>tools</p>
+        <Link to={"/tools"} className={styles.directory_box}>
+          <div className={styles.icon}>
+            <img src={DoubleRightArrow} alt="double_arrow-icon" />
+          </div>
+          <div className={styles.directory_text}>Tool Directory</div>
+        </Link>
+      </div>
+      {/* end of title box */}
+      <div className={styles.content_box}>
+        <span className={styles.cancel} onClick={showHeroSection}>
+          &times;
+        </span>
+        <div className={styles.content_wrap}>
+          <div className={styles.title}>
+            Powerful tools integrated just for Zuri chat
+          </div>
+          <p className={styles.text}>
+            Tools belong to you and your team, and they provide you extra
+            features to make you more productive. Install once and everyone can
+            make use of them.
+          </p>
+          <Link to={"/tools"} className={styles.btn}>
+            Browse available tools
+          </Link>
         </div>
-    )
-}
+        {/* end of content-wrap */}
+        <div className={styles.image_box}>
+          <figure className={styles.img_wrap}>
+            <img src={HeroLaptopImg} alt="" className={styles.img} />
+          </figure>
+        </div>
+      </div>
+      {/* end of content box */}
+    </div>
+  );
+};
 
-export default HeroSection
-
-
-
-
+export default HeroSection;
 
 // #242424  Powerful tools integrated just for Zuri chat
 // #3A3A3A    Tools belong to you and your team, and they provide you extra features to make you more productive. Install once and everyone can make use of them.

--- a/client/src/components/HeroSection/HeroSection.module.css
+++ b/client/src/components/HeroSection/HeroSection.module.css
@@ -1,197 +1,194 @@
-
-.hero_section{
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    margin: 1rem 0rem;
+.hero_section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  margin: 1rem 0rem;
 }
 
-.title_box{
-    color: #242424;
-    display: flex;
-    align-items: center;
-    margin-bottom: .6rem;
+.title_box {
+  color: #242424;
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.6rem;
 }
 
-.title_box .title{
-   text-transform: capitalize;
-   font-size: 15px;
-   font-weight: bold;
+.title_box .title {
+  text-transform: capitalize;
+  font-size: 15px;
+  font-weight: bold;
 }
 
-.title_box .directory_box{
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    color: #3A3A3A;
+.title_box .directory_box {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  color: #3a3a3a;
+  cursor: pointer;
 }
 
-.title_box .directory_box .icon{
-    margin-right: .5rem;
+.title_box .directory_box .icon {
+  margin-right: 0.5rem;
 }
 
-.title_box .directory_box .directory_text{
-    text-transform: capitalize;
+.title_box .directory_box .directory_text {
+  text-transform: capitalize;
 }
 
 .content_box {
+  width: 100%;
+  display: flex;
+  background-color: #ffffff;
+  padding: 0.3rem;
+  position: relative;
+  box-shadow: 0.1rem 0.1rem 0.4rem rgba(0, 0, 0, 0.2);
+  border-radius: 0.3rem;
+}
+
+.content_box .cancel {
+  position: absolute;
+  top: 0.3rem;
+  right: 1rem;
+  font-size: 2rem;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.content_box .cancel:hover {
+  transform: scale(1.1) translateY(-0.2rem);
+}
+
+.content_box .content_wrap {
+  flex: 0 0 65%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.content_box .content_wrap > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.content_box .content_wrap .title {
+  color: #242424;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.content_box .content_wrap .text {
+  color: #3a3a3a;
+  width: 85%;
+  font-size: 1rem;
+}
+
+.content_box .content_wrap .btn {
+  background-color: #009b69;
+  padding: 0.6rem 1rem;
+  color: #ffffff;
+  font-size: 1rem;
+  border-radius: 0.2rem;
+  margin-top: auto;
+  align-self: flex-start;
+  transition: all 0.3s;
+}
+
+.content_box .content_wrap .btn:hover {
+  transform: translateY(-0.1rem);
+}
+
+.content_box .image_box {
+  flex: 1;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.content_box .img_wrap {
+  height: 13rem;
+}
+
+.content_box .image_box .img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* media at 69em */
+
+@media only screen and (max-width: 69em) {
+  .title_box .title {
+    text-transform: capitalize;
+    font-size: 18px;
+    font-weight: bold;
+  }
+
+  .content_box .content_wrap {
+    flex: 0 0 60%;
+    padding: 1.2rem;
+  }
+
+  .content_box .content_wrap .title {
+    color: #242424;
+    font-size: 1.2rem;
+    font-weight: bold;
+  }
+
+  .content_box .content_wrap .text {
+    color: #3a3a3a;
     width: 100%;
-    display: flex;
-    background-color: #ffffff;
-    padding: .3rem;
-    position: relative;
-    box-shadow: .1rem .1rem .4rem rgba(0,0,0, .2);
-    border-radius: .3rem;
-}
-
-.content_box .cancel{
-    position: absolute;
-    top: .3rem;
-    right: 1rem;
-    font-size: 2rem;
-    cursor: pointer;
-    transition: all .3s;
-}
-
-.content_box .cancel:hover{
-    transform: scale(1.1) translateY(-.2rem);
-}
-
-.content_box .content_wrap{
-    flex: 0 0 65%;
-    padding: 1.5rem;
-    display: flex;
-    flex-direction: column;
-}
-
-.content_box .content_wrap > *:not(:last-child){
-    margin-bottom: 1rem;
-}
-
-.content_box .content_wrap .title{
-   color: #242424;
-   font-size: 1.5rem;
-   font-weight: bold;
-}
-
-.content_box .content_wrap .text{
-    color: #3A3A3A ;
-    width: 85%;
     font-size: 1rem;
-}
+  }
 
-.content_box .content_wrap .btn{
-    background-color: #009B69;
-    padding: .6rem 1rem;
+  .content_box .content_wrap .btn {
+    background-color: #009b69;
+    padding: 0.6rem 1rem;
     color: #ffffff;
     font-size: 1rem;
-    border-radius: .2rem;
+    border-radius: 0.2rem;
     margin-top: auto;
-    align-self: flex-start;  
-    transition: all .3s;
-}
+    align-self: flex-start;
+    transition: all 0.3s;
+  }
 
-.content_box .content_wrap .btn:hover{
-    transform: translateY(-.1rem);
-}
+  .content_box .content_wrap .btn:hover {
+    transform: translateY(-0.1rem);
+  }
 
-.content_box .image_box{
+  .content_box .image_box {
     flex: 1;
     padding: 2rem;
     display: flex;
     justify-content: center;
     align-items: center;
-}
+  }
 
-.content_box .img_wrap{
+  .content_box .img_wrap {
     height: 13rem;
-}
+  }
 
-.content_box .image_box .img{
+  .content_box .image_box .img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-}
-
-/* media at 69em */
-
-@media only screen and (max-width:69em){
-    
-    .title_box .title{
-       text-transform: capitalize;
-       font-size: 18px;
-       font-weight: bold;
-    }
-    
-    
-    .content_box .content_wrap{
-        flex: 0 0 60%;
-        padding: 1.2rem;
-    }
-    
-    
-    .content_box .content_wrap .title{
-       color: #242424;
-       font-size: 1.2rem;
-       font-weight: bold;
-    }
-    
-    .content_box .content_wrap .text{
-        color: #3A3A3A ;
-        width: 100%;
-        font-size: 1rem;
-    }
-    
-    .content_box .content_wrap .btn{
-        background-color: #009B69;
-        padding: .6rem 1rem;
-        color: #ffffff;
-        font-size: 1rem;
-        border-radius: .2rem;
-        margin-top: auto;
-        align-self: flex-start;  
-        transition: all .3s;
-    }
-    
-    .content_box .content_wrap .btn:hover{
-        transform: translateY(-.1rem);
-    }
-    
-    .content_box .image_box{
-        flex: 1;
-        padding: 2rem;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-    
-    .content_box .img_wrap{
-        height: 13rem;
-    }
-    
-    .content_box .image_box .img{
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
+  }
 }
 
 /* media at 60em */
 
-@media only screen and (max-width:60em){
-    .content_box{
-        flex-direction: column;
-    }
+@media only screen and (max-width: 60em) {
+  .content_box {
+    flex-direction: column;
+  }
 
-    .content_box .image_box{
-        display: none;
-    }
+  .content_box .image_box {
+    display: none;
+  }
 }
 
 /* media at 47em */
 
-@media only screen and (max-width:47em){
-    .content_box .content_wrap .title{
-        margin-top: 1rem;
-    }
+@media only screen and (max-width: 47em) {
+  .content_box .content_wrap .title {
+    margin-top: 1rem;
+  }
 }

--- a/client/src/components/MainPage/Instaledtoolssection.js
+++ b/client/src/components/MainPage/Instaledtoolssection.js
@@ -29,6 +29,7 @@ const InstalledTools = () => {
             .map(({ name, image, description, linkName }) => {
               return (
                 <InstallToolsCard
+                  key={name}
                   name={name}
                   image={image}
                   description={description}

--- a/client/src/components/MainPage/Instaledtoolssection.js
+++ b/client/src/components/MainPage/Instaledtoolssection.js
@@ -22,7 +22,7 @@ const InstalledTools = () => {
           <div>Filter</div>
         </div>
       </div>
-      <div className=" grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 ">
+      <div className=" grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 ">
         {tools &&
           tools
             .filter((tol) => tol.installed === true)

--- a/client/src/components/MainPage/installedcard.js
+++ b/client/src/components/MainPage/installedcard.js
@@ -78,7 +78,7 @@ const InstallToolsCard = ({ name, image, description, linkName }) => {
   };
   return (
     <div>
-      <Link to={`/${linkName}`}>
+      <Link to={`/${linkName}`} className="no-underline">
         <div className="flex ">
           <div className="bg-white flex w-full p-3 justify-center items-center space-x-4 rounded-lg cursor-pointer">
             <div className=" p-1 border border-gray-300 rounded-lg ">

--- a/client/src/components/MainTools/ToolsHeaderMain.js
+++ b/client/src/components/MainTools/ToolsHeaderMain.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronLeft, faAngleDown } from "@fortawesome/free-solid-svg-icons";
-import { Link } from "react-router-dom";
+// import { faChevronLeft, faAngleDown } from "@fortawesome/free-solid-svg-icons";
+// import { Link } from "react-router-dom";
 
 const ToolsHeaderMain = () => {
   return (

--- a/client/src/components/MainTools/ToolsHeaderMain.js
+++ b/client/src/components/MainTools/ToolsHeaderMain.js
@@ -7,7 +7,7 @@ const ToolsHeaderMain = () => {
   return (
     <div>
       <div className="flex flex-col mx-8 my-4">
-        <div className="flex justify-between  pb-3 mb-3">
+        {/* <div className="flex justify-between  pb-3 mb-3">
           <div className="font-black">Tools Directory</div>
           <Link to={"/"} className="no-underline">
             <div className="flex justify-between items-center space-x-2 cursor-pointer text-black">
@@ -17,7 +17,7 @@ const ToolsHeaderMain = () => {
               <div className="">Back to Tools</div>
             </div>
           </Link>
-        </div>
+        </div> */}
         <div className="border-b-2 border-gray-300">
           <div className="flex pb-8 ">
             <input

--- a/client/src/components/allroutes/appRoutesLayout.js
+++ b/client/src/components/allroutes/appRoutesLayout.js
@@ -1,32 +1,32 @@
 import React from "react";
 import { Route } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faAngleDoubleLeft } from "@fortawesome/free-solid-svg-icons";
-import { useHistory } from "react-router-dom";
+import { faChevronLeft } from "@fortawesome/free-solid-svg-icons";
+import { Link } from "react-router-dom";
 
-const AppLayout = ({ children }) => {
-  <div className="flex flex-grow min-h-screen">
-    <div className="flex-grow bg-gray-200">{children}</div>
-  </div>;
-};
+const AppLayout = ({ children }) => (
+  <div className="">
+    <div className="">{children}</div>
+  </div>
+);
 
 const AppLayoutRoutes = ({ component: Component, ...rest }) => {
-  const history = useHistory();
-
-  const handleClick = () => {
-    history.push("/");
-  };
-
   return (
     <div>
-      <div
-        onClick={handleClick}
-        className="cursor-pointer p-2 flex space-x-2  w-max rounded-full text-gray-700"
-      >
-        <div>
-          <FontAwesomeIcon icon={faAngleDoubleLeft} className="" />
+      <div className="mx-8 my-4">
+        <div className="flex justify-between mb-3">
+          <div className="font-black text-lg lg:text-lg xl:text-xl 2xl:text-2xl">
+            Tools Description
+          </div>
+          <Link to={"/"} className="no-underline">
+            <div className="flex justify-between items-center space-x-2 cursor-pointer text-black bg-gray-200 border-gray-400 px-2 py-1 hover:bg-gray-400  rounded-full transition transform duration-300 ease-in-out">
+              <div className="font-bold hover:text-white">
+                <FontAwesomeIcon icon={faChevronLeft} className="" />
+              </div>
+              <div className="hover:text-white">Back to Tools</div>
+            </div>
+          </Link>
         </div>
-        <div className="">Back to Main</div>
       </div>
       <Route
         {...rest}

--- a/client/src/components/allroutes/appRoutesLayout.js
+++ b/client/src/components/allroutes/appRoutesLayout.js
@@ -11,13 +11,20 @@ const AppLayout = ({ children }) => (
 );
 
 const AppLayoutRoutes = ({ component: Component, ...rest }) => {
+  // const history = useHistory();
+  // function capitalizeFirstLetter(string) {
+  //   return string.charAt(0).toUpperCase() + string.slice(1);
+  // }
+  // const name = history.location.pathname.slice(1);
+  // const capitalizedName = capitalizeFirstLetter(name);
+  // console.log("app layout", history.location.pathname);
   return (
     <div>
       <div className="mx-8 my-4">
         <div className="flex justify-between mb-3">
-          <div className="font-black text-lg lg:text-lg xl:text-xl 2xl:text-2xl">
-            Tools Description
-          </div>
+          {/* <div className="font-black text-lg lg:text-lg xl:text-xl 2xl:text-2xl">
+            {capitalizedName}
+          </div> */}
           <Link to={"/"} className="no-underline">
             <div className="flex justify-between items-center space-x-2 cursor-pointer text-black bg-gray-200 border-gray-400 px-2 py-1 hover:bg-gray-400  rounded-full transition transform duration-300 ease-in-out">
               <div className="font-bold hover:text-white">

--- a/client/src/components/allroutes/homeRoutesLayout.js
+++ b/client/src/components/allroutes/homeRoutesLayout.js
@@ -1,24 +1,22 @@
 import React from "react";
 import { Route } from "react-router-dom";
 
-const HomeLayout = ({ children }) => {
-  <div className="flex flex-grow min-h-screen">
-    <div className="flex-grow bg-gray-200">{children}</div>
-  </div>;
-};
+const HomeLayout = ({ children }) => (
+  <div className="">
+    <div className="">{children}</div>
+  </div>
+);
 
 const HomeLayoutRoutes = ({ component: Component, ...rest }) => {
   return (
-    <div>
-      <Route
-        {...rest}
-        render={(props) => (
-          <HomeLayout>
-            <Component {...props} />
-          </HomeLayout>
-        )}
-      />
-    </div>
+    <Route
+      {...rest}
+      render={(props) => (
+        <HomeLayout>
+          <Component {...props} />
+        </HomeLayout>
+      )}
+    />
   );
 };
 

--- a/client/src/components/allroutes/toolsDirectoryLayout.js
+++ b/client/src/components/allroutes/toolsDirectoryLayout.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { Route } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronLeft } from "@fortawesome/free-solid-svg-icons";
+import { Link } from "react-router-dom";
+
+const ToolsDirectory = ({ children }) => (
+  <div className="">
+    <div className="">{children}</div>
+  </div>
+);
+
+const ToolsDirectoryLayout = ({ component: Component, ...rest }) => {
+  return (
+    <div>
+      <div className="flex justify-between mx-8 mt-4  pb-3 mb-3">
+        <div className="font-black text-lg lg:text-lg xl:text-xl 2xl:text-2xl">
+          Tools Directory
+        </div>
+        <Link to={"/"} className="no-underline">
+          <div className="flex justify-between items-center space-x-2 cursor-pointer text-black bg-gray-200 border-gray-400 px-2 py-1 hover:bg-gray-400  rounded-full transition transform duration-300 ease-in-out">
+            <div className="font-bold hover:text-white">
+              <FontAwesomeIcon icon={faChevronLeft} className="" />
+            </div>
+            <div className="hover:text-white">Back to Tools</div>
+          </div>
+        </Link>
+      </div>
+      <Route
+        {...rest}
+        render={(props) => (
+          <ToolsDirectory>
+            <Component {...props} />
+          </ToolsDirectory>
+        )}
+      />
+    </div>
+  );
+};
+
+export default ToolsDirectoryLayout;


### PR DESCRIPTION
What does this PR do?
Fixes #373 

Live Link
https://externaltools.zuri.chat/github

Description of Task to be completed?
I created the header for all the installed apps home page, I integrated it with the layout structure of each installed apps, so as to ensure that that each page has a button that can be clicked to go back to the main page where you have the list of all installed apps

What is the link to the issue on Github?
#373 

Issue #373 