### PR TITLE
Make github home responsive

### DIFF
--- a/client/src/components/Apps/Github/Github.js
+++ b/client/src/components/Apps/Github/Github.js
@@ -10,8 +10,12 @@ const Github = () => {
       {/* <ToolsHeader /> */}
       <Router>
         <Switch>
-          <Route exact path="/github" component={GithubHome} />
-          <Route exact path="/github/github-installed" component={GithubInstalled} />
+          <Route exact path='/github' component={GithubHome} />
+          <Route
+            exact
+            path='/github/github-installed'
+            component={GithubInstalled}
+          />
         </Switch>
       </Router>
     </>

--- a/client/src/components/Apps/Github/containers/GithubHome.js
+++ b/client/src/components/Apps/Github/containers/GithubHome.js
@@ -1,6 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
-import { IoChevronBackOutline } from "react-icons/io5";
 import Image from "../assets/ZV_64LdGoao.jpg";
 import GithubLogo from "../assets/Rectangle 693.jpg";
 import "../style/GithubHome.css";


### PR DESCRIPTION
I made the github page mobile responsive with flexbox (categories section)

Categories section was flex-row instead of flex-column

I stacked components on top of each other, while on mobile view - not arranged side by side and causing a horizontal scroll. 

Live site: https://externaltools.zuri.chat/github

@Davien21 Pulled from the dev branch