### PR TITLE
Update filter function on the tools directory page + Add routes to installed tools on tools directory page + Create dropdown to filter based on categories.

### DIFF
--- a/client/src/components/ToolsDirectory/SearchFieldTools.js
+++ b/client/src/components/ToolsDirectory/SearchFieldTools.js
@@ -1,4 +1,4 @@
-import React, {useState, useRef} from 'react'
+import React, { useState, useRef } from "react";
 import styles from "./SearchFieldTools.module.css";
 import SearchIcon from "../../assets/search-icon.svg";
 
@@ -9,11 +9,11 @@ const SearchFieldTools = ({ sendInputText }) => {
   };
   return (
     <div className={styles.search_box}>
-      <img src={SearchIcon} className={styles.icon} alt="" />
+      <img src={SearchIcon} className={styles.icon} alt='search-icon' />
       <input
-        type="text"
+        type='text'
         className={styles.input}
-        placeholder="Search Tools"
+        placeholder='Search Tools'
         onChange={(e) => setInputText(e.currentTarget.value)}
         onKeyUp={sendInputTextToDirectory}
       />
@@ -21,4 +21,4 @@ const SearchFieldTools = ({ sendInputText }) => {
   );
 };
 
-export default SearchFieldTools
+export default SearchFieldTools;

--- a/client/src/components/ToolsDirectory/ToolsDirectory.js
+++ b/client/src/components/ToolsDirectory/ToolsDirectory.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from "react";
+import React, { useState, useEffect } from "react";
 import ToolsMainPage from "../MainTools/ToolsMain";
 import { tools } from "../../data/tools.data";
 import TitleBox from "../fragments/TitleBox";
@@ -7,79 +7,108 @@ import DailyTools from "../ToolsSection/DailyTools";
 import BotTools from "../ToolsSection/BotTools";
 import SearchFieldTools from "./SearchFieldTools";
 import CategoriesSection from "../fragments/CategoriesSection";
+import Container from "../sections/Container";
 
 const ToolsDirectory = () => {
   const [enterpriseList, setEnterpriseList] = useState([]);
-  const [dailyList, setDailyList] = useState([])
-  const [botList, setBotList] = useState([])
-  const [inputText, setInputText] = useState('')
+  const [dailyList, setDailyList] = useState([]);
+  const [botList, setBotList] = useState([]);
+  const [inputText, setInputText] = useState("");
 
   useEffect(() => {
     const getFetchList = async () => {
       const enterpriseFetch = await enterpriseFetchList();
       setEnterpriseList(enterpriseFetch);
       const dailyFetch = await dailyFetchList();
-      setDailyList(dailyFetch)
+      setDailyList(dailyFetch);
       const botFetch = await botFetchList();
-      setBotList(botFetch)
+      setBotList(botFetch);
     };
 
     getFetchList();
-  }, [])
-
+  }, []);
+  // Categories filter function start
+  // useEffect(() => {
+  //   effect;
+  //   return () => {
+  //     cleanup;
+  //   };
+  // }, [input]);
+  const handleCategoriesFilter = (category) => {};
+  // Categories filter function end
   const enterpriseFetchList = async () => {
-     const list = tools.filter((item) => item.enterprise)
-     return list
+    const list = tools.filter((item) => item.enterprise);
+    return list;
   };
   const dailyFetchList = async () => {
-    const list = tools.filter((item) => item.daily)
-    return list
-  }
+    const list = tools.filter((item) => item.daily);
+    return list;
+  };
   const botFetchList = async () => {
-    const list = tools.filter((item) => item.bot)
-    return list
-  }
-  const  upDateInputText = async (text) => {
-      setInputText(text)
-      const enterpriseList = shuffleEnterpriseList(text)
-      setEnterpriseList(enterpriseList)
-       const dailyList = shuffleDailyList(text)
-      setDailyList(dailyList)
-       const botList = shuffleBotList(text)
-      setBotList(botList)
-  }
+    const list = tools.filter((item) => item.bot);
+    return list;
+  };
+  const upDateInputText = async (text) => {
+    setInputText(text);
+    const enterpriseList = shuffleEnterpriseList(text);
+    setEnterpriseList(enterpriseList);
+    const dailyList = shuffleDailyList(text);
+    setDailyList(dailyList);
+    const botList = shuffleBotList(text);
+    setBotList(botList);
+  };
   const shuffleEnterpriseList = (text) => {
-    const list = tools.filter((item) => item.enterprise && item.name.toLocaleLowerCase().search(text.toLocaleLowerCase()) != -1)
-    return list
-  }
-   const shuffleDailyList = (text) => {
-     const list = tools.filter(
-       (item) =>
-         item.daily &&
-         item.name.toLocaleLowerCase().search(text.toLocaleLowerCase()) != -1
-     );
-     return list;
-   };
-    const shuffleBotList = (text) => {
-      const list = tools.filter(
-        (item) =>
-          item.bot &&
-          item.name.toLocaleLowerCase().search(text.toLocaleLowerCase()) != -1
-      );
-      return list;
-    };
+    const list = tools.filter(
+      (item) =>
+        item.enterprise &&
+        item.name.toLocaleLowerCase().search(text.toLocaleLowerCase()) != -1
+    );
+    return list;
+  };
+  const shuffleDailyList = (text) => {
+    const list = tools.filter(
+      (item) =>
+        item.daily &&
+        item.name.toLocaleLowerCase().search(text.toLocaleLowerCase()) != -1
+    );
+    return list;
+  };
+  const shuffleBotList = (text) => {
+    const list = tools.filter(
+      (item) =>
+        item.bot &&
+        item.name.toLocaleLowerCase().search(text.toLocaleLowerCase()) != -1
+    );
+    return list;
+  };
   return (
     <div style={{ padding: "12px 2rem" }}>
       {/* insert your component for those working on the company tools directory page */}
       {/* <ToolsMainPage /> */}
       <SearchFieldTools sendInputText={upDateInputText} />
       <CategoriesSection />
-      <TitleBox title="enterprise-ready apps" link={false} icon={false} />
-      <EnterpriseTools list={enterpriseList} text={inputText} />
-      <TitleBox title="daily tools" link={false} icon={false} />
-      <DailyTools list={dailyList} text={inputText} />
-      <TitleBox title="brilliant bots" link={false} icon={false} />
-      <BotTools list={botList} text={inputText}/>
+      {botList.length === 0 &&
+        enterpriseList.length === 0 &&
+        dailyList.length === 0 && (
+          <h2 className={`font-semibold text-center lg:text-lg text-base`}>
+            There is no search result for "{inputText}"
+          </h2>
+        )}
+      <Container
+        title={`enterprise-ready apps`}
+        toolsLength={enterpriseList.length}
+      >
+        <TitleBox title='enterprise-ready apps' link={false} icon={false} />
+        <EnterpriseTools list={enterpriseList} text={inputText} />
+      </Container>
+      <Container title={`daily tools`} toolsLength={dailyList.length}>
+        <TitleBox title='daily tools' link={false} icon={false} />
+        <DailyTools list={dailyList} text={inputText} />
+      </Container>
+      <Container title={`brilliant bots`} toolsLength={botList.length}>
+        <TitleBox title='brilliant bots' link={false} icon={false} />
+        <BotTools list={botList} text={inputText} />
+      </Container>
     </div>
   );
 };

--- a/client/src/components/ToolsDirectory/ToolsDirectory.js
+++ b/client/src/components/ToolsDirectory/ToolsDirectory.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import ToolsMainPage from "../MainTools/ToolsMain";
 import { tools } from "../../data/tools.data";
 import TitleBox from "../fragments/TitleBox";
@@ -14,6 +14,8 @@ const ToolsDirectory = () => {
   const [dailyList, setDailyList] = useState([]);
   const [botList, setBotList] = useState([]);
   const [inputText, setInputText] = useState("");
+  const [allCategories, setAllCategories] = useState([]);
+  const [allCategoriesContainer, setAllCategoriesContainer] = useState([]);
 
   useEffect(() => {
     const getFetchList = async () => {
@@ -27,15 +29,20 @@ const ToolsDirectory = () => {
 
     getFetchList();
   }, []);
-  // Categories filter function start
-  // useEffect(() => {
-  //   effect;
-  //   return () => {
-  //     cleanup;
-  //   };
-  // }, [input]);
+  // Categories filter function start //
+  const handleContainerRefArr = (ref) => {
+    setAllCategoriesContainer((oldRef) => {
+      return [...oldRef, ref];
+    });
+  };
+  const updateAllCategories = useCallback((category) => {
+    return setAllCategories((oldCategory) => {
+      let newCategory = [...oldCategory, category];
+      return newCategory;
+    });
+  }, []);
   const handleCategoriesFilter = (category) => {};
-  // Categories filter function end
+  // Categories filter function end //
   const enterpriseFetchList = async () => {
     const list = tools.filter((item) => item.enterprise);
     return list;
@@ -49,6 +56,9 @@ const ToolsDirectory = () => {
     return list;
   };
   const upDateInputText = async (text) => {
+    allCategoriesContainer.map((category) =>
+      category.removeAttribute("hidden")
+    );
     setInputText(text);
     const enterpriseList = shuffleEnterpriseList(text);
     setEnterpriseList(enterpriseList);
@@ -86,7 +96,10 @@ const ToolsDirectory = () => {
       {/* insert your component for those working on the company tools directory page */}
       {/* <ToolsMainPage /> */}
       <SearchFieldTools sendInputText={upDateInputText} />
-      <CategoriesSection />
+      <CategoriesSection
+        categories={allCategories}
+        categoriesContainer={allCategoriesContainer}
+      />
       {botList.length === 0 &&
         enterpriseList.length === 0 &&
         dailyList.length === 0 && (
@@ -97,16 +110,40 @@ const ToolsDirectory = () => {
       <Container
         title={`enterprise-ready apps`}
         toolsLength={enterpriseList.length}
+        updateRefArr={handleContainerRefArr}
       >
-        <TitleBox title='enterprise-ready apps' link={false} icon={false} />
+        <TitleBox
+          updateAllCategories={updateAllCategories}
+          title='enterprise-ready apps'
+          link={false}
+          icon={false}
+        />
         <EnterpriseTools list={enterpriseList} text={inputText} />
       </Container>
-      <Container title={`daily tools`} toolsLength={dailyList.length}>
-        <TitleBox title='daily tools' link={false} icon={false} />
+      <Container
+        title={`daily tools`}
+        toolsLength={dailyList.length}
+        updateRefArr={handleContainerRefArr}
+      >
+        <TitleBox
+          updateAllCategories={updateAllCategories}
+          title='daily tools'
+          link={false}
+          icon={false}
+        />
         <DailyTools list={dailyList} text={inputText} />
       </Container>
-      <Container title={`brilliant bots`} toolsLength={botList.length}>
-        <TitleBox title='brilliant bots' link={false} icon={false} />
+      <Container
+        title={`brilliant bots`}
+        toolsLength={botList.length}
+        updateRefArr={handleContainerRefArr}
+      >
+        <TitleBox
+          updateAllCategories={updateAllCategories}
+          title='brilliant bots'
+          link={false}
+          icon={false}
+        />
         <BotTools list={botList} text={inputText} />
       </Container>
     </div>

--- a/client/src/components/ToolsSection/BotTools.js
+++ b/client/src/components/ToolsSection/BotTools.js
@@ -1,13 +1,12 @@
-import React from 'react'
+import React from "react";
 import Tools from "../fragments/tools/Tools";
 import Tool from "../fragments/tools/Tool";
 
-const BotTools = ({list, text}) => {
-    return (
-        <div style={{ width: "100%", margin: "1rem 0rem 2rem 0rem" }}>
-        {
-            list.length > 0 ? (
-                <Tools>
+const BotTools = ({ list, text }) => {
+  return (
+    <div style={{ width: "100%", margin: "1rem 0rem 2rem 0rem" }}>
+      {list.length > 0 && (
+        <Tools>
           {list.map((item, index) => (
             <Tool
               key={index}
@@ -15,13 +14,13 @@ const BotTools = ({list, text}) => {
               title={item.name}
               text={item.description}
               pad={false}
+              item={item}
             />
           ))}
         </Tools>
-            ) : (`No result of  "${text}"  found for bot tools`)
-        }
-      </div>
-    )
-}
+      )}
+    </div>
+  );
+};
 
-export default BotTools
+export default BotTools;

--- a/client/src/components/ToolsSection/DailyTools.js
+++ b/client/src/components/ToolsSection/DailyTools.js
@@ -1,27 +1,26 @@
-import React from 'react'
+import React from "react";
 import Tools from "../fragments/tools/Tools";
 import Tool from "../fragments/tools/Tool";
 
-const DailyTools = ({list, text}) => {
-    return (
-      <div style={{ width: "100%", margin: "1rem 0rem 2rem 0rem" }}>
-        {list.length > 0 ? (
-          <Tools>
-            {list.map((item, index) => (
-              <Tool
-                key={index}
-                icon={item.image}
-                title={item.name}
-                text={item.description}
-                pad={false}
-              />
-            ))}
-          </Tools>
-        ) : (
-          `No result of  "${text}"  found for daily tools`
-        )}
-      </div>
-    );
-}
+const DailyTools = ({ list, text }) => {
+  return (
+    <div style={{ width: "100%", margin: "1rem 0rem 2rem 0rem" }}>
+      {list.length > 0 && (
+        <Tools>
+          {list.map((item, index) => (
+            <Tool
+              key={index}
+              icon={item.image}
+              title={item.name}
+              text={item.description}
+              pad={false}
+              item={item}
+            />
+          ))}
+        </Tools>
+      )}
+    </div>
+  );
+};
 
-export default DailyTools
+export default DailyTools;

--- a/client/src/components/ToolsSection/EnterpriseTools.js
+++ b/client/src/components/ToolsSection/EnterpriseTools.js
@@ -1,27 +1,26 @@
-import React from 'react'
+import React from "react";
 import Tools from "../fragments/tools/Tools";
-import Tool from '../fragments/tools/Tool';
+import Tool from "../fragments/tools/Tool";
 
-const EnterpriseTools = ({list, text}) => {
-    return (
-      <div style={{ width: "100%", margin: "1rem 0rem 2rem 0rem" }}>
-        {list.length > 0 ? (
-          <Tools>
-            {list.map((item, index) => (
-              <Tool
-                key={index}
-                icon={item.image}
-                title={item.name}
-                text={item.description}
-                pad={false}
-              />
-            ))}
-          </Tools>
-        ) : (
-          `No result of  "${text}"  found for enterprise tools`
-        )}
-      </div>
-    );
-}
+const EnterpriseTools = ({ list, text }) => {
+  return (
+    <div style={{ width: "100%", margin: "1rem 0rem 2rem 0rem" }}>
+      {list.length > 0 && (
+        <Tools>
+          {list.map((item, index) => (
+            <Tool
+              key={index}
+              icon={item.image}
+              title={item.name}
+              text={item.description}
+              pad={false}
+              item={item}
+            />
+          ))}
+        </Tools>
+      )}
+    </div>
+  );
+};
 
-export default EnterpriseTools
+export default EnterpriseTools;

--- a/client/src/components/fragments/CategoriesSection.js
+++ b/client/src/components/fragments/CategoriesSection.js
@@ -1,27 +1,81 @@
-import React from 'react'
-import styles from "./CategoriesSection.module.css"
-import DownArrow from "../../assets/down-arrow-icon.svg"
+import React, { useState } from "react";
+import styles from "./CategoriesSection.module.css";
+import DownArrow from "../../assets/down-arrow-icon.svg";
 
-const CategoriesSection = () => {
-    return (
-      <div className={styles.all_box}>
-        <h3 className={styles.title}>all</h3>
-        <div className={styles.categories_box}>
-          <div className={styles.box}>
-            <p className="text">Categories</p>
-            <img src={DownArrow} alt=""  className={styles.icon}/>
-          </div>
-          <div className={styles.box}>
-            <p className="text">Staff Picks</p>
-            <img src={DownArrow} alt="" className={styles.icon} />
-          </div>
-          <div className={styles.box}>
+const CategoriesSection = ({ categories, categoriesContainer }) => {
+  const [dropDownVisible, setdropDownVisible] = useState({
+    categoriesDropDown: false,
+    staffPicksDropDown: false,
+  });
+
+  const handleCategoriesFilter = (e) => {
+    const categoryName = e.target.innerHTML;
+    const filterCategories = categoriesContainer.filter(
+      (category) => category.id === categoryName
+    );
+    const hideCategories = categoriesContainer.filter(
+      (category) => category.id !== categoryName
+    );
+
+    filterCategories.map((category) => {
+      if (category.hasAttribute("hidden")) category.removeAttribute("hidden");
+    });
+    hideCategories.map((category) => category.setAttribute("hidden", true));
+  };
+
+  const handleCategoriesClick = (e) => {
+    setdropDownVisible({
+      categoriesDropDown: !dropDownVisible.categoriesDropDown,
+      staffPicksDropDown: false,
+    });
+  };
+  const handleStaffPicksClick = (e) => {
+    setdropDownVisible({
+      categoriesDropDown: false,
+      staffPicksDropDown: !dropDownVisible.categoriesDropDown,
+    });
+  };
+  return (
+    <div className={styles.all_box}>
+      <h3 className={styles.title}>all</h3>
+      <div className={styles.categories_box}>
+        <div
+          className={`${styles.box} cursor-pointer`}
+          id={`categoriesDropDown`}
+          onClick={handleCategoriesClick}
+        >
+          <p className='text'>Categories</p>
+          <img src={DownArrow} alt='' className={styles.icon} />
+          {dropDownVisible.categoriesDropDown && (
+            <div className={styles.dropdown}>
+              {categories.map((category, id) => {
+                return (
+                  <div
+                    key={id}
+                    className={styles.dropdownItem}
+                    onClick={handleCategoriesFilter}
+                  >
+                    {category}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <div
+          className={`${styles.box} cursor-pointer`}
+          onClick={handleStaffPicksClick}
+        >
+          <p className='text'>Staff Picks</p>
+          <img src={DownArrow} alt='' className={styles.icon} />
+        </div>
+        {/* <div className={styles.box}>
             <p className="text">Tool Collections</p>
             <img src={DownArrow} alt=""  className={styles.icon}/>
-          </div>
-        </div>
+          </div> */}
       </div>
-    );
-}
+    </div>
+  );
+};
 
-export default CategoriesSection
+export default CategoriesSection;

--- a/client/src/components/fragments/CategoriesSection.module.css
+++ b/client/src/components/fragments/CategoriesSection.module.css
@@ -1,58 +1,69 @@
-
-.all_box{
-    width: 100%;
-    margin: 1rem 0rem 2rem 0rem;
-    display: flex;
-    align-items: center;
-    color: #3A3A3A;
-    padding-bottom: .8rem;
-    border-bottom: .13rem solid #DADADA;
+.all_box {
+  width: 100%;
+  margin: 1rem 0rem 2rem 0rem;
+  display: flex;
+  align-items: center;
+  color: #3a3a3a;
+  padding-bottom: 0.8rem;
+  border-bottom: 0.13rem solid #dadada;
 }
 
-.all_box .title{
-    flex: 0 0 10%;
-    text-transform: capitalize;
+.all_box .title {
+  flex: 0 0 10%;
+  text-transform: capitalize;
 }
 
-.all_box .categories_box{
-    flex: 1;
-    display: flex;
-    align-items: center;
+.all_box .categories_box {
+  flex: 1;
+  display: flex;
+  align-items: center;
 }
 
-.all_box .categories_box .box{
-    display: flex;
-    align-items: center;
+.all_box .categories_box .box {
+  display: flex;
+  align-items: center;
+  @apply relative;
 }
 
-.all_box .categories_box .box:not(:first-child){
-    margin-left: 2.5rem;
+.all_box .categories_box .box:not(:first-child) {
+  margin-left: 2.5rem;
 }
 
-.all_box .categories_box .box .icon{
-    margin-left: .5rem;
+.all_box .categories_box .box .icon {
+  margin-left: 0.5rem;
 }
 
-
+.dropdown {
+  background: #3a3a3a;
+  @apply text-white;
+  @apply rounded;
+  @apply absolute top-full w-max z-50;
+  @apply capitalize;
+  @apply flex flex-col flex-nowrap;
+}
+.dropdownItem {
+  @apply p-1;
+  @apply hover:bg-figma-lineBg;
+}
 /* meida query for 38em */
 
-@media only screen and (max-width: 38em){
-    .all_box{
-        flex-direction: column;
-    }
-    .all_box .title{
-        align-self: flex-start;
-    }
-    .all_box .categories_box{
-        flex: 0 0 100%;
-        margin-top: .5rem;
-        justify-content: space-between;
-    }
+@media only screen and (max-width: 38em) {
+  .all_box {
+    flex-direction: column;
+  }
+  .all_box .title {
+    align-self: flex-start;
+  }
+  .all_box .categories_box {
+    flex: 0 0 100%;
+    margin-top: 0.5rem;
+    justify-content: space-between;
+  }
 
-    .all_box .categories_box .box{
-        margin-left: 0rem;  
-    }
-    .all_box .categories_box .box .icon{
-    margin-left: .2rem;
-}
+  .all_box .categories_box .box {
+    margin-left: 0rem;
+  }
+  .all_box .categories_box .box .icon {
+    margin-left: 0.2rem;
+  }
 }

--- a/client/src/components/fragments/TitleBox.js
+++ b/client/src/components/fragments/TitleBox.js
@@ -1,22 +1,27 @@
-import React from 'react'
-import styles from "../HeroSection/HeroSection.module.css"
-import DoubleRightArrow from "../../assets/tool-icon.svg"
-import {Link} from "react-router-dom"
+import React, { useEffect } from "react";
+import styles from "../HeroSection/HeroSection.module.css";
+import DoubleRightArrow from "../../assets/tool-icon.svg";
+import { Link } from "react-router-dom";
 
-const TitleBox = ({title, text, link , icon}) => {
-    return (
-      <div className={styles.title_box}>
-        <p className={styles.title}>{title}</p>
-        <Link to={`${link ? "/tools" : ""}`} className={styles.directory_box}>
-          {icon && (
-            <div className={styles.icon}>
-              <img src={DoubleRightArrow} alt="double_arrow-icon" />
-            </div>
-          )}
-          <div className={styles.directory_text}>{text}</div>
-        </Link>
-      </div>
-    );
-}
+const TitleBox = ({ title, text, link, icon, updateAllCategories }) => {
+  useEffect(() => {
+    if (updateAllCategories) {
+      updateAllCategories(title);
+    }
+  }, []);
+  return (
+    <div className={styles.title_box}>
+      <p className={styles.title}>{title}</p>
+      <Link to={`${link ? "/tools" : ""}`} className={styles.directory_box}>
+        {icon && (
+          <div className={styles.icon}>
+            <img src={DoubleRightArrow} alt='double_arrow-icon' />
+          </div>
+        )}
+        <div className={styles.directory_text}>{text}</div>
+      </Link>
+    </div>
+  );
+};
 
-export default TitleBox
+export default TitleBox;

--- a/client/src/components/fragments/tools/Tool.js
+++ b/client/src/components/fragments/tools/Tool.js
@@ -1,29 +1,52 @@
-import React from 'react'
+import React from "react";
+import { Link } from "react-router-dom";
 
-import styles from "./Tools.module.css"
+import styles from "./Tools.module.css";
 
-const Tool = ({icon, title, text, btn, pad}) => {
-    return (
-        <div className={styles.tool}>
-            <div className={styles.icon_title_box}>
-                <figure className={styles.img_box}><img src={icon} alt="" className={styles.img} /></figure>
-                <div className={styles.title_box}>
-               <h3 className = {styles.title} >{title}</h3>
-               <p className={styles.text}>{text}</p>
-                </div>
+const Tool = ({ icon, title, text, btn, pad, item }) => {
+  const { installed, path } = item;
+  return (
+    <div className={styles.tool}>
+      {installed ? (
+        <Link to={path}>
+          <div className={styles.icon_title_box}>
+            <figure className={styles.img_box}>
+              <img src={icon} alt='' className={styles.img} />
+            </figure>
+            <div className={styles.title_box}>
+              <h3 className={styles.title}>{title}</h3>
+              <p className={styles.text}>{text}</p>
             </div>
-            {/* end of title icon box */}
-            <button style={{
-                backgroundColor: "#F0EFEF",
-                borderRadius: ".2rem",
-                color: "#3A3A3A",
-                textTransform: "capitalize",
-                textAlign: "center",
-                marginTop: ".7rem",
-                padding: `${pad && ".3rem"}`
-            }}>{btn}</button>
+          </div>
+        </Link>
+      ) : (
+        <div className={styles.icon_title_box}>
+          <figure className={styles.img_box}>
+            <img src={icon} alt='' className={styles.img} />
+          </figure>
+          <div className={styles.title_box}>
+            <h3 className={styles.title}>{title}</h3>
+            <p className={styles.text}>{text}</p>
+          </div>
         </div>
-    )
-}
+      )}
 
-export default Tool
+      {/* end of title icon box */}
+      <button
+        style={{
+          backgroundColor: "#F0EFEF",
+          borderRadius: ".2rem",
+          color: "#3A3A3A",
+          textTransform: "capitalize",
+          textAlign: "center",
+          marginTop: ".7rem",
+          padding: `${pad && ".3rem"}`,
+        }}
+      >
+        {btn}
+      </button>
+    </div>
+  );
+};
+
+export default Tool;

--- a/client/src/components/fragments/tools/Tools.module.css
+++ b/client/src/components/fragments/tools/Tools.module.css
@@ -1,92 +1,89 @@
-
-.tool_box{
-    display: grid;
+.tool_box {
+  /* display: grid;
     grid-template-columns: repeat(auto-fit, minmax(18rem, 19rem));
     grid-gap: 1.4rem;
     grid-column-gap: 1.68rem;
-    margin: 1rem 0rem;
-    justify-content: flex-start;
-}   
-
-@media only screen and (max-width:39em){
-  .tool_box{
+    */
+  margin: 1rem 0rem;
+  @apply grid lg:grid-cols-4 md:grid-cols-2 gap-y-6 gap-x-7 grid-cols-1;
+  justify-content: flex-start;
+}
+@media only screen and (max-width: 39em) {
+  /* .tool_box {
     grid-template-columns: repeat(auto-fit, minmax(25rem, 1fr));
-    justify-content: center; 
+    justify-content: center;
+  } */
+}
+
+.tool_box .tool {
+  background-color: #ffffff;
+  padding: 1rem;
+  border-radius: 0.3rem;
+  box-shadow: 0.1rem 0.1rem 0.4rem rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  transition: all 0.3s;
+  border: 0.1rem solid rgba(153, 153, 153, 0.5);
+  width: 100%;
+}
+
+.tool_box .tool:hover {
+  transform: scale(1.01);
+}
+
+.tool_box .tool .icon_title_box {
+  display: flex;
+  align-items: center;
+}
+
+.tool_box .tool .icon_title_box .title_box {
+  display: flex;
+  flex-direction: column;
+  margin-right: 0.5rem;
+}
+
+.tool_box .tool .icon_title_box .img_box {
+  height: 3.7rem;
+  width: 7rem;
+  padding: 0.2rem;
+  border: 0.05rem solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.2rem;
+  margin-right: 0.8rem;
+}
+
+@media only screen and (max-width: 39em) {
+  .tool_box .tool .icon_title_box .img_box {
+    width: 5.5rem;
   }
 }
 
-.tool_box .tool{
-    background-color: #ffffff;
-    padding: 1rem;
-    border-radius: .3rem;
-    box-shadow: .1rem .1rem .4rem rgba(0,0,0, .1);
-    display: flex;
-    flex-direction: column;
-    cursor: pointer;
-    transition: all .3s;
-    border: .1rem solid rgba(153, 153, 153, 0.5);
-    width: 100%;
+.tool_box .tool .icon_title_box .img_box .img {
+  height: 100%;
+  width: 100%;
+  display: block;
+  object-fit: contain;
 }
 
-.tool_box .tool:hover{
-    transform: scale(1.01);
+.tool_box .tool .icon_title_box .title_box .title {
+  font-size: 1.2rem;
+  font-weight: bold;
+  text-transform: capitalize;
+  color: #242424;
+  margin-bottom: 0.3rem;
 }
 
-.tool_box .tool .icon_title_box{
-    display: flex;
-    align-items: center;
+.tool_box .tool .icon_title_box .title_box .text {
+  font-size: 0.75rem;
+  color: #767676;
 }
 
-.tool_box .tool .icon_title_box .title_box{
-    display: flex;
-    flex-direction: column;
-    margin-right: .5rem;
+.tool_box .tool .btn {
+  background-color: #f0efef;
+  border-radius: 0.2rem;
+  color: #3a3a3a;
+  text-transform: capitalize;
+  text-align: center;
+  margin-top: 0.7rem;
+  padding: 0.3rem;
 }
-
-
-
-.tool_box .tool .icon_title_box .img_box{
-   height: 3.7rem;
-   width:  7rem;
-   padding: .2rem;
-   border: .05rem solid rgba(0,0,0, .1);
-   border-radius: .2rem;
-   margin-right: .8rem;  
-}
-
-@media only screen and (max-width: 39em){
-    .tool_box .tool .icon_title_box .img_box{
-        width: 5.5rem;
-    }
-}
-
-.tool_box .tool .icon_title_box .img_box .img{
-    height: 100%;
-    width: 100%;
-    display: block;
-    object-fit: contain;
-}
-
-.tool_box .tool .icon_title_box .title_box .title{
-    font-size: 1.2rem;
-    font-weight: bold;
-    text-transform: capitalize;
-    color: #242424;
-    margin-bottom: .3rem;
-}
-
-.tool_box .tool .icon_title_box .title_box .text{
-    font-size: .75rem;
-    color: #767676;
-}
-
-/* .tool_box .tool .btn{
-    background-color: #F0EFEF;
-    border-radius: .2rem;
-    color: #3A3A3A;
-    text-transform: capitalize;
-    text-align: center;
-    margin-top: .7rem;
-    padding: .3rem;
-} */
-

--- a/client/src/components/sections/Container.jsx
+++ b/client/src/components/sections/Container.jsx
@@ -1,13 +1,19 @@
 import React, { useRef, useEffect } from "react";
 
-const Container = ({ className, children, title, toolsLength }) => {
+const Container = ({
+  className,
+  children,
+  title,
+  toolsLength,
+  updateRefArr,
+}) => {
   const containerRef = useRef(false);
   const { current } = containerRef;
   useEffect(() => {
     if (current) {
-      set;
+      updateRefArr(current);
     }
-  }, [containerRef]);
+  }, [current]);
   return (
     <div
       className={`${className} ${toolsLength === 0 && `hidden`}`}

--- a/client/src/components/sections/Container.jsx
+++ b/client/src/components/sections/Container.jsx
@@ -1,7 +1,22 @@
-import React from 'react'
+import React, { useRef, useEffect } from "react";
 
-const Container = ({ className, children }) => {
-    return <div className={className}>{children}</div>
-}
+const Container = ({ className, children, title, toolsLength }) => {
+  const containerRef = useRef(false);
+  const { current } = containerRef;
+  useEffect(() => {
+    if (current) {
+      set;
+    }
+  }, [containerRef]);
+  return (
+    <div
+      className={`${className} ${toolsLength === 0 && `hidden`}`}
+      id={title}
+      ref={containerRef}
+    >
+      {children}
+    </div>
+  );
+};
 
-export default Container
+export default Container;

--- a/client/src/data/tools.data.js
+++ b/client/src/data/tools.data.js
@@ -8,6 +8,7 @@ export const tools = [
     categoryClass: "enterpriseApp",
     linkName: "gmail",
     installed: true,
+    path: "/gmail",
     daily: true,
   },
   {
@@ -18,6 +19,7 @@ export const tools = [
     categoryClass: "enterpriseApp",
     linkName: "figma",
     installed: true,
+    path: "/figma",
     daily: true,
   },
   {
@@ -28,6 +30,7 @@ export const tools = [
     categoryClass: "billiantBots",
     linkName: "github",
     installed: true,
+    path: "/github",
     daily: true,
   },
   {
@@ -38,6 +41,7 @@ export const tools = [
     categoryClass: "workFromHome",
     linkName: "googledrive",
     installed: true,
+    path: "/googledrive",
     daily: true,
   },
   {
@@ -48,6 +52,7 @@ export const tools = [
     categoryClass: "billiantBots",
     linkName: "giphy",
     installed: true,
+    path: "/giphy",
   },
   {
     name: "Facebook",


### PR DESCRIPTION
Update the filter function on the tools directory page, also add routes to installed tools on directory pages. *new* Create dropdown menu to filter categories based on their category name.

When the search input on the tools directory page does not match any of the apps in the directory, all categories don't display on the page and a error text is displayed.
Installed apps - such as Gmail, Github, Figma, google drive - displayed on the tools directory page now route to their apps e.g baselink/github.
*NEW*
Clicking on categories now displays a dropdown menu with the feature of filtering apps based on their category.

@hokagedemehin please review